### PR TITLE
CLN: add `{:target=_blank}` to links

### DIFF
--- a/about.md
+++ b/about.md
@@ -6,10 +6,10 @@ permalink: /about/
 
 Hi, I'm Logan.
 
-I currently work for [Enthought](https://www.enthought.com/) as a Scientific Software Developer and Technical Trainer. Previously, I worked for a protective design firm as a machine learning engineer and I've also been employed as a data scientist in the digital media industry.
+I currently work for [Enthought](https://www.enthought.com/){:target="_blank"} as a Scientific Software Developer and Technical Trainer. Previously, I worked for a protective design firm as a machine learning engineer and I've also been employed as a data scientist in the digital media industry.
 
 I am passionate about software and love sharing my knowledge with others. This is my personal blog where I share helpful information about data science, machine learning, and python.
 
 If you're interested in discussing any of the topics listed on this site, looking for training/mentorship, or just want to catch up over a cup of coffee (in-person or remote), feel free to reach out to me at [logan.thomas005@gmail.com](mailto:logan.thomas005@gmail.com?subject=[Website Contact])
 
-To see other things I'm working on, checkout my GitHub page: [loganthomas](https://github.com/loganthomas)
+To see other things I'm working on, checkout my GitHub page: [loganthomas](https://github.com/loganthomas){:target="_blank"}


### PR DESCRIPTION
Double-check to ensure all external links open in a new window
- Note: the links in the turkeybowl section are _internal_ links, so should **not** open in a new window when navigating to the archive, etc.