### PR TITLE
FMT: hide turkey bowl in nav bar

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,7 +6,7 @@
   link: /tutorials/
 - name: Talks
   link: /talks/
-- name: Turkey Bowl
-  link: /turkey_bowl/
+# - name: Turkey Bowl
+#   link: /turkey_bowl/
 - name: Tags
   link: /tags/


### PR DESCRIPTION
Turkey bowl page **will still be accessible** (just not if you don't know about it).
- Idea is to hide to make the personal website a bit more professional.
- Closes #32 