### PR TITLE
CLN: add custom css to remove site header

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,13 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+.site-header {
+    // border-top: 5px solid $grey-color-dark;
+    border-bottom: 1px solid $grey-color-light;
+    min-height: $spacing-unit * 1.865;
+
+    // Positioning context for the mobile navigation icon
+    position: relative;
+}


### PR DESCRIPTION
Currently, there is a dark line across the site. This is hard to see when chrome in in dark mode, but evident when in light mode.

<img width="1679" alt="Screen Shot 2023-07-24 at 13 34 15" src="https://github.com/loganthomas/loganthomas.github.io/assets/24984410/016feb27-53cd-4bd4-882f-616647713777">

This is not an issue with the HTML or CSS but actually the default for `minima` theme: https://jekyll.github.io/minima/
<img width="1668" alt="Screen Shot 2023-07-24 at 13 36 12" src="https://github.com/loganthomas/loganthomas.github.io/assets/24984410/44eaeb06-949e-4a90-8165-24942ba1a9ab">

## Solution
https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll#customizing-your-themes-css
- Be sure to update local `minima` to reflect this as well (possible for local and GitHub pages to be out of sync)

```
$ bundle info --path minima
/usr/local/lib/ruby/gems/3.0.0/gems/minima-2.5.1
```
- Open above in vscode and search for "site-header" (or whatever element you're trying to change)
- Update in the local and within `assets/css/style.scss` file
- For example, both files were updated with `site-header` as below

```
.site-header {
    // border-top: 5px solid $grey-color-dark;
    border-bottom: 1px solid $grey-color-light;
    min-height: $spacing-unit * 1.865;

    // Positioning context for the mobile navigation icon
    position: relative;
}
```

